### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/zerosheepmoo/8cf20701-b263-40a7-8cd0-c7606bdf4d29/085af49f-32fd-498b-8d67-a7121c0680e6/_apis/work/boardbadge/c63fb793-e666-4ecb-a53b-3fe40dbac8ef)](https://dev.azure.com/zerosheepmoo/8cf20701-b263-40a7-8cd0-c7606bdf4d29/_boards/board/t/085af49f-32fd-498b-8d67-a7121c0680e6/Microsoft.RequirementCategory)
 # hayangbum-study
 
 ## 숙제 파일 제출


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/zerosheepmoo/8cf20701-b263-40a7-8cd0-c7606bdf4d29/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.